### PR TITLE
refactor: update webgl not found hint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readr-media/pannellum-react",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Pannellum React Component",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/pannellum/js/pannellum.js
+++ b/src/pannellum/js/pannellum.js
@@ -125,8 +125,9 @@ if (typeof window !== "undefined") {
           "Due to iOS 8's broken WebGL implementation, only " +
           "progressive encoded JPEGs work for your device (this " +
           "panorama uses standard encoding).",
+        // Due to chrome user may turn off the hardware acceleration which will cause the WebGL not found, show the chinese hint to guide user turn it on.
         genericWebGLError:
-          "Your browser does not have the necessary WebGL support to display this panorama.",
+          "你的瀏覽器或版本不支援顯示，建議使用 Chrome/Safari 來開啟或升級瀏覽器版本。若使用 Chrome 仍無法開啟，請在設定>系統中開啟「使用圖形加速功能」。",
         textureSizeError:
           "This panorama is too big for your device! It's " +
           "%spx wide, but your device only supports images up to " +


### PR DESCRIPTION
Chrome 使用者如果在設定中 (下列步驟) 關閉圖形加速器功能，將會觸發 genericWebGLError 錯誤，針對中文使用者提供開啟相關設定的建議。

chrome (v123.0.6312.87) 設定方式： 設定 > 系統 > 使用圖形加速功能 (如果可用) 